### PR TITLE
Add fan creations lightbox with media viewer

### DIFF
--- a/client/components/ui/sonner.tsx
+++ b/client/components/ui/sonner.tsx
@@ -1,14 +1,11 @@
-import { useTheme } from "next-themes";
 import { Toaster as Sonner } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="dark"
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/client/lib/spotify-playlist.ts
+++ b/client/lib/spotify-playlist.ts
@@ -103,7 +103,7 @@ class SpotifyPlaylistAPI {
    */
   async getPlaylistTracks(playlistId: string): Promise<PlaylistTrack[]> {
     if (!playlistId || playlistId === "YOUR_PLAYLIST_ID_HERE") {
-      console.warn("⚠️ Playlist ID not configured. Using mock data.");
+      console.warn("���️ Playlist ID not configured. Using mock data.");
       return this.getMockTracks();
     }
 
@@ -174,25 +174,32 @@ class SpotifyPlaylistAPI {
   private getMockTracks(): PlaylistTrack[] {
     return [
       {
-        id: "mock1",
-        name: "Sample Track 1",
-        spotifyUrl: "https://open.spotify.com/track/example1",
-        albumCover: "https://via.placeholder.com/300x300/333/fff?text=Track+1",
-        artist: "Sample Artist",
+        id: "1",
+        name: "Sacred Queer Heart",
+        spotifyUrl: "https://open.spotify.com/track/5iuWm1EbaACpLVqs5jEplm?si=c0828c8edcb641a6",
+        albumCover: "https://via.placeholder.com/300x300/ff00de/ffffff?text=SQH",
+        artist: "Shelby Mackay",
       },
       {
-        id: "mock2",
-        name: "Sample Track 2",
-        spotifyUrl: "https://open.spotify.com/track/example2",
-        albumCover: "https://via.placeholder.com/300x300/333/fff?text=Track+2",
-        artist: "Sample Artist",
+        id: "2",
+        name: "Moongirlnonsense",
+        spotifyUrl: "https://open.spotify.com/track/53NYm8PTesJSSMSMoyljeh?si=5d6c3dcc88674138",
+        albumCover: "https://via.placeholder.com/300x300/00ffff/ffffff?text=MGN",
+        artist: "Shelby Mackay",
       },
       {
-        id: "mock3",
-        name: "Sample Track 3",
-        spotifyUrl: "https://open.spotify.com/track/example3",
-        albumCover: "https://via.placeholder.com/300x300/333/fff?text=Track+3",
-        artist: "Sample Artist",
+        id: "3",
+        name: "Stillelectricwhenshesdown",
+        spotifyUrl: "https://open.spotify.com/track/3CY4ZmQ067SPACan76Wj5B?si=7b652d81525a4371",
+        albumCover: "https://via.placeholder.com/300x300/39ff14/ffffff?text=SEWS",
+        artist: "Shelby Mackay",
+      },
+      {
+        id: "4",
+        name: "Dontforgetmypeace",
+        spotifyUrl: "https://open.spotify.com/track/5JdLlW10WLuhWnxfhCednE?si=3c33e8ef46544dc2",
+        albumCover: "https://via.placeholder.com/300x300/8a2be2/ffffff?text=DFMP",
+        artist: "Shelby Mackay",
       },
     ];
   }

--- a/client/lib/spotify-playlist.ts
+++ b/client/lib/spotify-playlist.ts
@@ -176,29 +176,37 @@ class SpotifyPlaylistAPI {
       {
         id: "1",
         name: "Sacred Queer Heart",
-        spotifyUrl: "https://open.spotify.com/track/5iuWm1EbaACpLVqs5jEplm?si=c0828c8edcb641a6",
-        albumCover: "https://via.placeholder.com/300x300/ff00de/ffffff?text=SQH",
+        spotifyUrl:
+          "https://open.spotify.com/track/5iuWm1EbaACpLVqs5jEplm?si=c0828c8edcb641a6",
+        albumCover:
+          "https://via.placeholder.com/300x300/ff00de/ffffff?text=SQH",
         artist: "Shelby Mackay",
       },
       {
         id: "2",
         name: "Moongirlnonsense",
-        spotifyUrl: "https://open.spotify.com/track/53NYm8PTesJSSMSMoyljeh?si=5d6c3dcc88674138",
-        albumCover: "https://via.placeholder.com/300x300/00ffff/ffffff?text=MGN",
+        spotifyUrl:
+          "https://open.spotify.com/track/53NYm8PTesJSSMSMoyljeh?si=5d6c3dcc88674138",
+        albumCover:
+          "https://via.placeholder.com/300x300/00ffff/ffffff?text=MGN",
         artist: "Shelby Mackay",
       },
       {
         id: "3",
         name: "Stillelectricwhenshesdown",
-        spotifyUrl: "https://open.spotify.com/track/3CY4ZmQ067SPACan76Wj5B?si=7b652d81525a4371",
-        albumCover: "https://via.placeholder.com/300x300/39ff14/ffffff?text=SEWS",
+        spotifyUrl:
+          "https://open.spotify.com/track/3CY4ZmQ067SPACan76Wj5B?si=7b652d81525a4371",
+        albumCover:
+          "https://via.placeholder.com/300x300/39ff14/ffffff?text=SEWS",
         artist: "Shelby Mackay",
       },
       {
         id: "4",
         name: "Dontforgetmypeace",
-        spotifyUrl: "https://open.spotify.com/track/5JdLlW10WLuhWnxfhCednE?si=3c33e8ef46544dc2",
-        albumCover: "https://via.placeholder.com/300x300/8a2be2/ffffff?text=DFMP",
+        spotifyUrl:
+          "https://open.spotify.com/track/5JdLlW10WLuhWnxfhCednE?si=3c33e8ef46544dc2",
+        albumCover:
+          "https://via.placeholder.com/300x300/8a2be2/ffffff?text=DFMP",
         artist: "Shelby Mackay",
       },
     ];

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -968,14 +968,14 @@ export default function Index() {
       {/* Cyberpunk Lightbox Modal for Fan Creations */}
       <Dialog open={lightboxOpen} onOpenChange={setLightboxOpen}>
         <DialogContent
-          className="max-w-4xl w-[90vw] h-[90vh] p-0 overflow-hidden cyber-border bg-cyber-dark/95 backdrop-blur-lg border-2"
+          className="max-w-5xl w-[95vw] h-[95vh] p-0 overflow-hidden cyber-border bg-cyber-dark/95 backdrop-blur-lg border-2 [&>button]:hidden"
           style={{ borderColor: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
         >
           <div className="relative w-full h-full flex flex-col">
             {/* Header */}
-            <div className="flex items-center justify-between p-4 bg-cyber-deep/50 border-b border-neon-cyan/30">
-              <div>
-                <DialogTitle className="text-xl font-bold font-mono neon-text"
+            <div className="flex items-center justify-between p-4 bg-cyber-deep/50 border-b border-neon-cyan/30 shrink-0">
+              <div className="min-w-0">
+                <DialogTitle className="text-xl font-bold font-mono neon-text truncate"
                   style={{ color: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
                 >
                   {currentMedia?.title}
@@ -986,14 +986,14 @@ export default function Index() {
               </div>
               <button
                 onClick={closeLightbox}
-                className="w-10 h-10 rounded-full bg-cyber-deep/80 border-2 border-neon-pink hover:border-neon-cyan transition-colors flex items-center justify-center hover-glow group"
+                className="w-10 h-10 rounded-full bg-cyber-deep/80 border-2 border-neon-pink hover:border-neon-cyan transition-colors flex items-center justify-center hover-glow group shrink-0 ml-4"
               >
                 <X className="w-5 h-5 text-neon-pink group-hover:text-neon-cyan transition-colors" />
               </button>
             </div>
 
             {/* Media Content */}
-            <div className="flex-1 flex items-center justify-center p-4 bg-gradient-to-br from-cyber-dark to-cyber-deep">
+            <div className="flex-1 flex items-center justify-center p-6 bg-gradient-to-br from-cyber-dark to-cyber-deep min-h-0">
               {currentMedia?.type === 'image' ? (
                 <motion.img
                   initial={{ opacity: 0, scale: 0.8 }}
@@ -1001,8 +1001,9 @@ export default function Index() {
                   transition={{ duration: 0.3 }}
                   src={currentMedia.src}
                   alt={currentMedia.title}
-                  className="max-w-full max-h-full object-contain rounded-lg cyber-border"
-                  style={{ borderColor: '#ff00de' }}
+                  className="max-w-full max-h-full object-contain rounded-lg cyber-border shadow-2xl cursor-pointer"
+                  style={{ borderColor: '#ff00de', boxShadow: '0 0 30px rgba(255, 0, 222, 0.3)' }}
+                  onClick={closeLightbox}
                 />
               ) : (
                 <motion.video
@@ -1012,8 +1013,8 @@ export default function Index() {
                   src={currentMedia?.src}
                   controls
                   autoPlay
-                  className="max-w-full max-h-full object-contain rounded-lg cyber-border"
-                  style={{ borderColor: '#8a2be2' }}
+                  className="max-w-full max-h-full object-contain rounded-lg cyber-border shadow-2xl"
+                  style={{ borderColor: '#8a2be2', boxShadow: '0 0 30px rgba(138, 43, 226, 0.3)' }}
                 >
                   Your browser does not support the video tag.
                 </motion.video>
@@ -1021,7 +1022,7 @@ export default function Index() {
             </div>
 
             {/* Footer with metadata */}
-            <div className="p-4 bg-cyber-deep/50 border-t border-neon-cyan/30">
+            <div className="p-4 bg-cyber-deep/50 border-t border-neon-cyan/30 shrink-0">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-4">
                   <div className="flex items-center space-x-2">
@@ -1039,16 +1040,16 @@ export default function Index() {
                   </div>
                 </div>
                 <div className="text-xs text-muted-foreground font-mono">
-                  ESC or click X to close
+                  ESC, click X, or click image to close
                 </div>
               </div>
             </div>
 
             {/* Cyberpunk decorative elements */}
-            <div className="absolute top-4 left-4 w-2 h-2 bg-neon-cyan rounded-full animate-pulse opacity-60" />
-            <div className="absolute top-8 left-8 w-1 h-1 bg-neon-green rounded-full animate-glow-pulse opacity-40" />
-            <div className="absolute bottom-4 right-4 w-2 h-2 bg-neon-orange rounded-full animate-pulse opacity-60" />
-            <div className="absolute bottom-8 right-8 w-1 h-1 bg-neon-violet rounded-full animate-glow-pulse opacity-40" />
+            <div className="absolute top-16 left-4 w-2 h-2 bg-neon-cyan rounded-full animate-pulse opacity-60 pointer-events-none" />
+            <div className="absolute top-20 left-8 w-1 h-1 bg-neon-green rounded-full animate-glow-pulse opacity-40 pointer-events-none" />
+            <div className="absolute bottom-16 right-4 w-2 h-2 bg-neon-orange rounded-full animate-pulse opacity-60 pointer-events-none" />
+            <div className="absolute bottom-20 right-8 w-1 h-1 bg-neon-violet rounded-full animate-glow-pulse opacity-40 pointer-events-none" />
           </div>
         </DialogContent>
       </Dialog>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -445,8 +445,14 @@ export default function Index() {
               {/* Fan Image 2 */}
               <motion.div
                 whileHover={{ scale: 1.02, y: -5 }}
-                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#39ff14" }}
+                onClick={() => openLightbox(
+                  "https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F2103096b7b674ed0b1f9e73c33e94c45?format=webp&width=800",
+                  "DIGITAL.REMIX",
+                  "Y2K aesthetic interpretation",
+                  "image"
+                )}
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <img
@@ -456,6 +462,11 @@ export default function Index() {
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-neon-green/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-green rounded-full animate-glow-pulse" />
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <div className="w-12 h-12 rounded-full bg-cyber-dark/90 border-2 border-neon-green flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
+                      <span className="text-neon-green text-lg font-mono">👁</span>
+                    </div>
+                  </div>
                 </div>
                 <div className="space-y-2">
                   <h3 className="text-lg font-bold text-neon-green font-mono">DIGITAL.REMIX</h3>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -964,6 +964,94 @@ export default function Index() {
           />
         ))}
       </div>
+
+      {/* Cyberpunk Lightbox Modal for Fan Creations */}
+      <Dialog open={lightboxOpen} onOpenChange={setLightboxOpen}>
+        <DialogContent
+          className="max-w-4xl w-[90vw] h-[90vh] p-0 overflow-hidden cyber-border bg-cyber-dark/95 backdrop-blur-lg border-2"
+          style={{ borderColor: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
+        >
+          <div className="relative w-full h-full flex flex-col">
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 bg-cyber-deep/50 border-b border-neon-cyan/30">
+              <div>
+                <DialogTitle className="text-xl font-bold font-mono neon-text"
+                  style={{ color: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
+                >
+                  {currentMedia?.title}
+                </DialogTitle>
+                <p className="text-sm text-cyber-glow font-mono mt-1">
+                  {currentMedia?.description}
+                </p>
+              </div>
+              <button
+                onClick={closeLightbox}
+                className="w-10 h-10 rounded-full bg-cyber-deep/80 border-2 border-neon-pink hover:border-neon-cyan transition-colors flex items-center justify-center hover-glow group"
+              >
+                <X className="w-5 h-5 text-neon-pink group-hover:text-neon-cyan transition-colors" />
+              </button>
+            </div>
+
+            {/* Media Content */}
+            <div className="flex-1 flex items-center justify-center p-4 bg-gradient-to-br from-cyber-dark to-cyber-deep">
+              {currentMedia?.type === 'image' ? (
+                <motion.img
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: 0.3 }}
+                  src={currentMedia.src}
+                  alt={currentMedia.title}
+                  className="max-w-full max-h-full object-contain rounded-lg cyber-border"
+                  style={{ borderColor: '#ff00de' }}
+                />
+              ) : (
+                <motion.video
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: 0.3 }}
+                  src={currentMedia?.src}
+                  controls
+                  autoPlay
+                  className="max-w-full max-h-full object-contain rounded-lg cyber-border"
+                  style={{ borderColor: '#8a2be2' }}
+                >
+                  Your browser does not support the video tag.
+                </motion.video>
+              )}
+            </div>
+
+            {/* Footer with metadata */}
+            <div className="p-4 bg-cyber-deep/50 border-t border-neon-cyan/30">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <div className="flex items-center space-x-2">
+                    <div
+                      className="w-3 h-3 rounded-full animate-glow-pulse"
+                      style={{ backgroundColor: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
+                    />
+                    <span className="text-xs text-cyber-glow font-mono">
+                      {currentMedia?.type === 'video' ? 'VIDEO.CONTENT' : 'IMAGE.CONTENT'}
+                    </span>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <div className="w-2 h-2 bg-neon-green rounded-full animate-pulse" />
+                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                  </div>
+                </div>
+                <div className="text-xs text-muted-foreground font-mono">
+                  ESC or click X to close
+                </div>
+              </div>
+            </div>
+
+            {/* Cyberpunk decorative elements */}
+            <div className="absolute top-4 left-4 w-2 h-2 bg-neon-cyan rounded-full animate-pulse opacity-60" />
+            <div className="absolute top-8 left-8 w-1 h-1 bg-neon-green rounded-full animate-glow-pulse opacity-40" />
+            <div className="absolute bottom-4 right-4 w-2 h-2 bg-neon-orange rounded-full animate-pulse opacity-60" />
+            <div className="absolute bottom-8 right-8 w-1 h-1 bg-neon-violet rounded-full animate-glow-pulse opacity-40" />
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -481,23 +481,34 @@ export default function Index() {
               {/* Fan Video 1 */}
               <motion.div
                 whileHover={{ scale: 1.02, y: -5 }}
-                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#8a2be2" }}
+                onClick={() => openLightbox(
+                  "https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F51fd544a1c4941d186270781a55343f2?alt=media&token=e68710f2-1c68-4220-94df-3f432cbcb9f9&apiKey=0633d7dd76bc46b5ae429b203d2a5219",
+                  "MOTION.GRAPHICS",
+                  "Fan-created visual experience",
+                  "video"
+                )}
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <video
-                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105"
-                    controls
+                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105 pointer-events-none"
+                    muted
                     preload="metadata"
                   >
                     <source src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F51fd544a1c4941d186270781a55343f2?alt=media&token=e68710f2-1c68-4220-94df-3f432cbcb9f9&apiKey=0633d7dd76bc46b5ae429b203d2a5219" type="video/mp4" />
                     Your browser does not support the video tag.
                   </video>
-                  <div className="absolute inset-0 bg-gradient-to-t from-neon-violet/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-neon-violet/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                   <div className="absolute top-2 left-2 px-2 py-1 bg-cyber-deep/80 rounded text-xs font-mono text-neon-violet">
                     VIDEO
                   </div>
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-violet rounded-full animate-glow-pulse" />
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <div className="w-16 h-16 rounded-full bg-cyber-dark/90 border-2 border-neon-violet flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
+                      <span className="text-neon-violet text-2xl font-mono">▶</span>
+                    </div>
+                  </div>
                 </div>
                 <div className="space-y-2">
                   <h3 className="text-lg font-bold text-neon-violet font-mono">MOTION.GRAPHICS</h3>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -57,6 +57,15 @@ export default function Index() {
   const [isLoadingReleases, setIsLoadingReleases] = useState(true);
   const [apiError, setApiError] = useState<string | null>(null);
 
+  // Lightbox state for fan creations
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [currentMedia, setCurrentMedia] = useState<{
+    src: string;
+    title: string;
+    description: string;
+    type: 'image' | 'video';
+  } | null>(null);
+
   const socialLinks = [
     {
       name: "SPOTIFY",

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -362,6 +362,159 @@ export default function Index() {
           </div>
         </motion.div>
 
+        {/* Fan Features Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 50 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 1, delay: 1.5 }}
+          className="max-w-6xl mx-auto mb-16"
+        >
+          <div
+            className="cyber-border bg-cyber-deep/50 p-8 rounded-lg backdrop-blur-sm"
+            style={{ borderColor: "#00ffff" }}
+          >
+            <h2 className="text-2xl font-bold text-neon-cyan mb-6 font-mono neon-text text-center">
+              ◯ FAN.CREATIONS
+            </h2>
+            <p className="text-center text-cyber-glow font-mono mb-8 text-lg">
+              &gt; DIGITAL ART FROM THE COMMUNITY_
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              {/* Fan Image 1 */}
+              <motion.div
+                whileHover={{ scale: 1.02, y: -5 }}
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                style={{ borderColor: "#ff00de" }}
+              >
+                <div className="relative overflow-hidden rounded-lg mb-4">
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F5d25bf673e48461eaef1a2efe579780d?format=webp&width=800"
+                    alt="Fan Art - Cyberpunk Portrait"
+                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-110"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-neon-pink/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <div className="absolute top-2 right-2 w-3 h-3 bg-neon-pink rounded-full animate-glow-pulse" />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-lg font-bold text-neon-pink font-mono">CYBERPUNK.PORTRAIT</h3>
+                  <p className="text-sm text-muted-foreground font-mono">Digital fan art creation</p>
+                  <div className="flex items-center space-x-2">
+                    <div className="w-2 h-2 bg-neon-pink rounded-full animate-pulse" />
+                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                  </div>
+                </div>
+              </motion.div>
+
+              {/* Fan Image 2 */}
+              <motion.div
+                whileHover={{ scale: 1.02, y: -5 }}
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                style={{ borderColor: "#39ff14" }}
+              >
+                <div className="relative overflow-hidden rounded-lg mb-4">
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F2103096b7b674ed0b1f9e73c33e94c45?format=webp&width=800"
+                    alt="Fan Art - Digital Creation"
+                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-110"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-neon-green/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <div className="absolute top-2 right-2 w-3 h-3 bg-neon-green rounded-full animate-glow-pulse" />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-lg font-bold text-neon-green font-mono">DIGITAL.REMIX</h3>
+                  <p className="text-sm text-muted-foreground font-mono">Y2K aesthetic interpretation</p>
+                  <div className="flex items-center space-x-2">
+                    <div className="w-2 h-2 bg-neon-green rounded-full animate-pulse" />
+                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                  </div>
+                </div>
+              </motion.div>
+
+              {/* Fan Video 1 */}
+              <motion.div
+                whileHover={{ scale: 1.02, y: -5 }}
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                style={{ borderColor: "#8a2be2" }}
+              >
+                <div className="relative overflow-hidden rounded-lg mb-4">
+                  <video
+                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105"
+                    controls
+                    preload="metadata"
+                  >
+                    <source src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F51fd544a1c4941d186270781a55343f2?alt=media&token=e68710f2-1c68-4220-94df-3f432cbcb9f9&apiKey=0633d7dd76bc46b5ae429b203d2a5219" type="video/mp4" />
+                    Your browser does not support the video tag.
+                  </video>
+                  <div className="absolute inset-0 bg-gradient-to-t from-neon-violet/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+                  <div className="absolute top-2 left-2 px-2 py-1 bg-cyber-deep/80 rounded text-xs font-mono text-neon-violet">
+                    VIDEO
+                  </div>
+                  <div className="absolute top-2 right-2 w-3 h-3 bg-neon-violet rounded-full animate-glow-pulse" />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-lg font-bold text-neon-violet font-mono">MOTION.GRAPHICS</h3>
+                  <p className="text-sm text-muted-foreground font-mono">Fan-created visual experience</p>
+                  <div className="flex items-center space-x-2">
+                    <div className="w-2 h-2 bg-neon-violet rounded-full animate-pulse" />
+                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                  </div>
+                </div>
+              </motion.div>
+
+              {/* Fan Video 2 */}
+              <motion.div
+                whileHover={{ scale: 1.02, y: -5 }}
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                style={{ borderColor: "#ff6b35" }}
+              >
+                <div className="relative overflow-hidden rounded-lg mb-4">
+                  <video
+                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105"
+                    controls
+                    preload="metadata"
+                  >
+                    <source src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F0c18f6bff0c940049a6f3cb93f7f5352?alt=media&token=c79a662a-b373-4fe6-bbf1-349f69cb8cfc&apiKey=0633d7dd76bc46b5ae429b203d2a5219" type="video/mp4" />
+                    Your browser does not support the video tag.
+                  </video>
+                  <div className="absolute inset-0 bg-gradient-to-t from-neon-orange/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+                  <div className="absolute top-2 left-2 px-2 py-1 bg-cyber-deep/80 rounded text-xs font-mono text-neon-orange">
+                    VIDEO
+                  </div>
+                  <div className="absolute top-2 right-2 w-3 h-3 bg-neon-orange rounded-full animate-glow-pulse" />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-lg font-bold text-neon-orange font-mono">VISUAL.REMIX</h3>
+                  <p className="text-sm text-muted-foreground font-mono">Creative interpretation</p>
+                  <div className="flex items-center space-x-2">
+                    <div className="w-2 h-2 bg-neon-orange rounded-full animate-pulse" />
+                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                  </div>
+                </div>
+              </motion.div>
+            </div>
+
+            {/* Call to Action */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 2 }}
+              className="mt-8 text-center"
+            >
+              <div className="cyber-border bg-cyber-deep/20 p-4 rounded-lg backdrop-blur-sm inline-block"
+                style={{ borderColor: "#00ffff" }}
+              >
+                <p className="text-cyber-glow font-mono text-sm mb-2">
+                  &gt; SUBMIT YOUR CREATION_
+                </p>
+                <p className="text-muted-foreground font-mono text-xs">
+                  Tag @sheldoradoshellshock on Instagram to be featured
+                </p>
+              </div>
+            </motion.div>
+          </div>
+        </motion.div>
+
         {/* Music Player Section */}
         <motion.div
           initial={{ opacity: 0, scale: 0.9 }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { Instagram, Youtube } from "lucide-react";
+import { Instagram, Youtube, X } from "lucide-react";
 import {
   spotifyPlaylistAPI,
   PLAYLIST_ID,
   PlaylistTrack,
 } from "@/lib/spotify-playlist";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 // Custom brand logo components
 const SpotifyLogo = ({

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -523,23 +523,34 @@ export default function Index() {
               {/* Fan Video 2 */}
               <motion.div
                 whileHover={{ scale: 1.02, y: -5 }}
-                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#ff6b35" }}
+                onClick={() => openLightbox(
+                  "https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F0c18f6bff0c940049a6f3cb93f7f5352?alt=media&token=c79a662a-b373-4fe6-bbf1-349f69cb8cfc&apiKey=0633d7dd76bc46b5ae429b203d2a5219",
+                  "VISUAL.REMIX",
+                  "Creative interpretation",
+                  "video"
+                )}
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <video
-                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105"
-                    controls
+                    className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105 pointer-events-none"
+                    muted
                     preload="metadata"
                   >
                     <source src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F0c18f6bff0c940049a6f3cb93f7f5352?alt=media&token=c79a662a-b373-4fe6-bbf1-349f69cb8cfc&apiKey=0633d7dd76bc46b5ae429b203d2a5219" type="video/mp4" />
                     Your browser does not support the video tag.
                   </video>
-                  <div className="absolute inset-0 bg-gradient-to-t from-neon-orange/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-neon-orange/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                   <div className="absolute top-2 left-2 px-2 py-1 bg-cyber-deep/80 rounded text-xs font-mono text-neon-orange">
                     VIDEO
                   </div>
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-orange rounded-full animate-glow-pulse" />
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <div className="w-16 h-16 rounded-full bg-cyber-dark/90 border-2 border-neon-orange flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
+                      <span className="text-neon-orange text-2xl font-mono">▶</span>
+                    </div>
+                  </div>
                 </div>
                 <div className="space-y-2">
                   <h3 className="text-lg font-bold text-neon-orange font-mono">VISUAL.REMIX</h3>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -89,6 +89,17 @@ export default function Index() {
     },
   ];
 
+  // Helper functions for lightbox
+  const openLightbox = (src: string, title: string, description: string, type: 'image' | 'video') => {
+    setCurrentMedia({ src, title, description, type });
+    setLightboxOpen(true);
+  };
+
+  const closeLightbox = () => {
+    setLightboxOpen(false);
+    setCurrentMedia(null);
+  };
+
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
       setMousePosition({

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -993,7 +993,7 @@ export default function Index() {
             </div>
 
             {/* Media Content */}
-            <div className="flex-1 flex items-center justify-center p-6 bg-gradient-to-br from-cyber-dark to-cyber-deep min-h-0">
+            <div className="flex-1 flex items-center justify-center p-4 bg-gradient-to-br from-cyber-dark to-cyber-deep min-h-0 overflow-hidden">
               {currentMedia?.type === 'image' ? (
                 <motion.img
                   initial={{ opacity: 0, scale: 0.8 }}
@@ -1001,8 +1001,13 @@ export default function Index() {
                   transition={{ duration: 0.3 }}
                   src={currentMedia.src}
                   alt={currentMedia.title}
-                  className="max-w-full max-h-full object-contain rounded-lg cyber-border shadow-2xl cursor-pointer"
-                  style={{ borderColor: '#ff00de', boxShadow: '0 0 30px rgba(255, 0, 222, 0.3)' }}
+                  className="w-full h-full object-contain rounded-lg cyber-border shadow-2xl cursor-pointer"
+                  style={{
+                    borderColor: '#ff00de',
+                    boxShadow: '0 0 30px rgba(255, 0, 222, 0.3)',
+                    maxWidth: 'calc(100vw - 4rem)',
+                    maxHeight: 'calc(100vh - 12rem)'
+                  }}
                   onClick={closeLightbox}
                 />
               ) : (
@@ -1013,8 +1018,13 @@ export default function Index() {
                   src={currentMedia?.src}
                   controls
                   autoPlay
-                  className="max-w-full max-h-full object-contain rounded-lg cyber-border shadow-2xl"
-                  style={{ borderColor: '#8a2be2', boxShadow: '0 0 30px rgba(138, 43, 226, 0.3)' }}
+                  className="w-full h-full object-contain rounded-lg cyber-border shadow-2xl"
+                  style={{
+                    borderColor: '#8a2be2',
+                    boxShadow: '0 0 30px rgba(138, 43, 226, 0.3)',
+                    maxWidth: 'calc(100vw - 4rem)',
+                    maxHeight: 'calc(100vh - 12rem)'
+                  }}
                 >
                   Your browser does not support the video tag.
                 </motion.video>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -6,11 +6,7 @@ import {
   PLAYLIST_ID,
   PlaylistTrack,
 } from "@/lib/spotify-playlist";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
 // Custom brand logo components
 const SpotifyLogo = ({
@@ -63,7 +59,7 @@ export default function Index() {
     src: string;
     title: string;
     description: string;
-    type: 'image' | 'video';
+    type: "image" | "video";
   } | null>(null);
 
   const socialLinks = [
@@ -90,7 +86,12 @@ export default function Index() {
   ];
 
   // Helper functions for lightbox
-  const openLightbox = (src: string, title: string, description: string, type: 'image' | 'video') => {
+  const openLightbox = (
+    src: string,
+    title: string,
+    description: string,
+    type: "image" | "video",
+  ) => {
     setCurrentMedia({ src, title, description, type });
     setLightboxOpen(true);
   };
@@ -411,12 +412,14 @@ export default function Index() {
                 whileHover={{ scale: 1.02, y: -5 }}
                 className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#ff00de" }}
-                onClick={() => openLightbox(
-                  "https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F5d25bf673e48461eaef1a2efe579780d?format=webp&width=800",
-                  "CYBERPUNK.PORTRAIT",
-                  "Digital fan art creation",
-                  "image"
-                )}
+                onClick={() =>
+                  openLightbox(
+                    "https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F5d25bf673e48461eaef1a2efe579780d?format=webp&width=800",
+                    "CYBERPUNK.PORTRAIT",
+                    "Digital fan art creation",
+                    "image",
+                  )
+                }
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <img
@@ -428,16 +431,24 @@ export default function Index() {
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-pink rounded-full animate-glow-pulse" />
                   <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                     <div className="w-12 h-12 rounded-full bg-cyber-dark/90 border-2 border-neon-pink flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
-                      <span className="text-neon-pink text-lg font-mono">👁</span>
+                      <span className="text-neon-pink text-lg font-mono">
+                        👁
+                      </span>
                     </div>
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <h3 className="text-lg font-bold text-neon-pink font-mono">CYBERPUNK.PORTRAIT</h3>
-                  <p className="text-sm text-muted-foreground font-mono">Digital fan art creation</p>
+                  <h3 className="text-lg font-bold text-neon-pink font-mono">
+                    CYBERPUNK.PORTRAIT
+                  </h3>
+                  <p className="text-sm text-muted-foreground font-mono">
+                    Digital fan art creation
+                  </p>
                   <div className="flex items-center space-x-2">
                     <div className="w-2 h-2 bg-neon-pink rounded-full animate-pulse" />
-                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                    <span className="text-xs text-cyber-glow font-mono">
+                      COMMUNITY_UPLOAD
+                    </span>
                   </div>
                 </div>
               </motion.div>
@@ -447,12 +458,14 @@ export default function Index() {
                 whileHover={{ scale: 1.02, y: -5 }}
                 className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#39ff14" }}
-                onClick={() => openLightbox(
-                  "https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F2103096b7b674ed0b1f9e73c33e94c45?format=webp&width=800",
-                  "DIGITAL.REMIX",
-                  "Y2K aesthetic interpretation",
-                  "image"
-                )}
+                onClick={() =>
+                  openLightbox(
+                    "https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F2103096b7b674ed0b1f9e73c33e94c45?format=webp&width=800",
+                    "DIGITAL.REMIX",
+                    "Y2K aesthetic interpretation",
+                    "image",
+                  )
+                }
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <img
@@ -464,16 +477,24 @@ export default function Index() {
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-green rounded-full animate-glow-pulse" />
                   <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                     <div className="w-12 h-12 rounded-full bg-cyber-dark/90 border-2 border-neon-green flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
-                      <span className="text-neon-green text-lg font-mono">👁</span>
+                      <span className="text-neon-green text-lg font-mono">
+                        👁
+                      </span>
                     </div>
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <h3 className="text-lg font-bold text-neon-green font-mono">DIGITAL.REMIX</h3>
-                  <p className="text-sm text-muted-foreground font-mono">Y2K aesthetic interpretation</p>
+                  <h3 className="text-lg font-bold text-neon-green font-mono">
+                    DIGITAL.REMIX
+                  </h3>
+                  <p className="text-sm text-muted-foreground font-mono">
+                    Y2K aesthetic interpretation
+                  </p>
                   <div className="flex items-center space-x-2">
                     <div className="w-2 h-2 bg-neon-green rounded-full animate-pulse" />
-                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                    <span className="text-xs text-cyber-glow font-mono">
+                      COMMUNITY_UPLOAD
+                    </span>
                   </div>
                 </div>
               </motion.div>
@@ -483,12 +504,14 @@ export default function Index() {
                 whileHover={{ scale: 1.02, y: -5 }}
                 className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#8a2be2" }}
-                onClick={() => openLightbox(
-                  "https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F51fd544a1c4941d186270781a55343f2?alt=media&token=e68710f2-1c68-4220-94df-3f432cbcb9f9&apiKey=0633d7dd76bc46b5ae429b203d2a5219",
-                  "MOTION.GRAPHICS",
-                  "Fan-created visual experience",
-                  "video"
-                )}
+                onClick={() =>
+                  openLightbox(
+                    "https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F51fd544a1c4941d186270781a55343f2?alt=media&token=e68710f2-1c68-4220-94df-3f432cbcb9f9&apiKey=0633d7dd76bc46b5ae429b203d2a5219",
+                    "MOTION.GRAPHICS",
+                    "Fan-created visual experience",
+                    "video",
+                  )
+                }
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <video
@@ -496,7 +519,10 @@ export default function Index() {
                     muted
                     preload="metadata"
                   >
-                    <source src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F51fd544a1c4941d186270781a55343f2?alt=media&token=e68710f2-1c68-4220-94df-3f432cbcb9f9&apiKey=0633d7dd76bc46b5ae429b203d2a5219" type="video/mp4" />
+                    <source
+                      src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F51fd544a1c4941d186270781a55343f2?alt=media&token=e68710f2-1c68-4220-94df-3f432cbcb9f9&apiKey=0633d7dd76bc46b5ae429b203d2a5219"
+                      type="video/mp4"
+                    />
                     Your browser does not support the video tag.
                   </video>
                   <div className="absolute inset-0 bg-gradient-to-t from-neon-violet/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
@@ -506,16 +532,24 @@ export default function Index() {
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-violet rounded-full animate-glow-pulse" />
                   <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                     <div className="w-16 h-16 rounded-full bg-cyber-dark/90 border-2 border-neon-violet flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
-                      <span className="text-neon-violet text-2xl font-mono">▶</span>
+                      <span className="text-neon-violet text-2xl font-mono">
+                        ▶
+                      </span>
                     </div>
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <h3 className="text-lg font-bold text-neon-violet font-mono">MOTION.GRAPHICS</h3>
-                  <p className="text-sm text-muted-foreground font-mono">Fan-created visual experience</p>
+                  <h3 className="text-lg font-bold text-neon-violet font-mono">
+                    MOTION.GRAPHICS
+                  </h3>
+                  <p className="text-sm text-muted-foreground font-mono">
+                    Fan-created visual experience
+                  </p>
                   <div className="flex items-center space-x-2">
                     <div className="w-2 h-2 bg-neon-violet rounded-full animate-pulse" />
-                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                    <span className="text-xs text-cyber-glow font-mono">
+                      COMMUNITY_UPLOAD
+                    </span>
                   </div>
                 </div>
               </motion.div>
@@ -525,12 +559,14 @@ export default function Index() {
                 whileHover={{ scale: 1.02, y: -5 }}
                 className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#ff6b35" }}
-                onClick={() => openLightbox(
-                  "https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F0c18f6bff0c940049a6f3cb93f7f5352?alt=media&token=c79a662a-b373-4fe6-bbf1-349f69cb8cfc&apiKey=0633d7dd76bc46b5ae429b203d2a5219",
-                  "VISUAL.REMIX",
-                  "Creative interpretation",
-                  "video"
-                )}
+                onClick={() =>
+                  openLightbox(
+                    "https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F0c18f6bff0c940049a6f3cb93f7f5352?alt=media&token=c79a662a-b373-4fe6-bbf1-349f69cb8cfc&apiKey=0633d7dd76bc46b5ae429b203d2a5219",
+                    "VISUAL.REMIX",
+                    "Creative interpretation",
+                    "video",
+                  )
+                }
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <video
@@ -538,7 +574,10 @@ export default function Index() {
                     muted
                     preload="metadata"
                   >
-                    <source src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F0c18f6bff0c940049a6f3cb93f7f5352?alt=media&token=c79a662a-b373-4fe6-bbf1-349f69cb8cfc&apiKey=0633d7dd76bc46b5ae429b203d2a5219" type="video/mp4" />
+                    <source
+                      src="https://cdn.builder.io/o/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F0c18f6bff0c940049a6f3cb93f7f5352?alt=media&token=c79a662a-b373-4fe6-bbf1-349f69cb8cfc&apiKey=0633d7dd76bc46b5ae429b203d2a5219"
+                      type="video/mp4"
+                    />
                     Your browser does not support the video tag.
                   </video>
                   <div className="absolute inset-0 bg-gradient-to-t from-neon-orange/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
@@ -548,16 +587,24 @@ export default function Index() {
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-orange rounded-full animate-glow-pulse" />
                   <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                     <div className="w-16 h-16 rounded-full bg-cyber-dark/90 border-2 border-neon-orange flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
-                      <span className="text-neon-orange text-2xl font-mono">▶</span>
+                      <span className="text-neon-orange text-2xl font-mono">
+                        ▶
+                      </span>
                     </div>
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <h3 className="text-lg font-bold text-neon-orange font-mono">VISUAL.REMIX</h3>
-                  <p className="text-sm text-muted-foreground font-mono">Creative interpretation</p>
+                  <h3 className="text-lg font-bold text-neon-orange font-mono">
+                    VISUAL.REMIX
+                  </h3>
+                  <p className="text-sm text-muted-foreground font-mono">
+                    Creative interpretation
+                  </p>
                   <div className="flex items-center space-x-2">
                     <div className="w-2 h-2 bg-neon-orange rounded-full animate-pulse" />
-                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                    <span className="text-xs text-cyber-glow font-mono">
+                      COMMUNITY_UPLOAD
+                    </span>
                   </div>
                 </div>
               </motion.div>
@@ -570,7 +617,8 @@ export default function Index() {
               transition={{ delay: 2 }}
               className="mt-8 text-center"
             >
-              <div className="cyber-border bg-cyber-deep/20 p-4 rounded-lg backdrop-blur-sm inline-block"
+              <div
+                className="cyber-border bg-cyber-deep/20 p-4 rounded-lg backdrop-blur-sm inline-block"
                 style={{ borderColor: "#00ffff" }}
               >
                 <p className="text-cyber-glow font-mono text-sm mb-2">
@@ -969,14 +1017,20 @@ export default function Index() {
       <Dialog open={lightboxOpen} onOpenChange={setLightboxOpen}>
         <DialogContent
           className="max-w-5xl w-[95vw] h-[95vh] p-0 overflow-hidden cyber-border bg-cyber-dark/95 backdrop-blur-lg border-2 [&>button]:hidden"
-          style={{ borderColor: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
+          style={{
+            borderColor: currentMedia?.type === "video" ? "#8a2be2" : "#ff00de",
+          }}
         >
           <div className="relative w-full h-full flex flex-col">
             {/* Header */}
             <div className="flex items-center justify-between p-4 bg-cyber-deep/50 border-b border-neon-cyan/30 shrink-0">
               <div className="min-w-0">
-                <DialogTitle className="text-xl font-bold font-mono neon-text truncate"
-                  style={{ color: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
+                <DialogTitle
+                  className="text-xl font-bold font-mono neon-text truncate"
+                  style={{
+                    color:
+                      currentMedia?.type === "video" ? "#8a2be2" : "#ff00de",
+                  }}
                 >
                   {currentMedia?.title}
                 </DialogTitle>
@@ -994,7 +1048,7 @@ export default function Index() {
 
             {/* Media Content */}
             <div className="flex-1 flex items-center justify-center p-4 bg-gradient-to-br from-cyber-dark to-cyber-deep min-h-0 overflow-hidden">
-              {currentMedia?.type === 'image' ? (
+              {currentMedia?.type === "image" ? (
                 <motion.img
                   initial={{ opacity: 0, scale: 0.8 }}
                   animate={{ opacity: 1, scale: 1 }}
@@ -1003,10 +1057,10 @@ export default function Index() {
                   alt={currentMedia.title}
                   className="w-full h-full object-contain rounded-lg cyber-border shadow-2xl cursor-pointer"
                   style={{
-                    borderColor: '#ff00de',
-                    boxShadow: '0 0 30px rgba(255, 0, 222, 0.3)',
-                    maxWidth: 'calc(100vw - 4rem)',
-                    maxHeight: 'calc(100vh - 12rem)'
+                    borderColor: "#ff00de",
+                    boxShadow: "0 0 30px rgba(255, 0, 222, 0.3)",
+                    maxWidth: "calc(100vw - 4rem)",
+                    maxHeight: "calc(100vh - 12rem)",
                   }}
                   onClick={closeLightbox}
                 />
@@ -1020,10 +1074,10 @@ export default function Index() {
                   autoPlay
                   className="w-full h-full object-contain rounded-lg cyber-border shadow-2xl"
                   style={{
-                    borderColor: '#8a2be2',
-                    boxShadow: '0 0 30px rgba(138, 43, 226, 0.3)',
-                    maxWidth: 'calc(100vw - 4rem)',
-                    maxHeight: 'calc(100vh - 12rem)'
+                    borderColor: "#8a2be2",
+                    boxShadow: "0 0 30px rgba(138, 43, 226, 0.3)",
+                    maxWidth: "calc(100vw - 4rem)",
+                    maxHeight: "calc(100vh - 12rem)",
                   }}
                 >
                   Your browser does not support the video tag.
@@ -1038,15 +1092,24 @@ export default function Index() {
                   <div className="flex items-center space-x-2">
                     <div
                       className="w-3 h-3 rounded-full animate-glow-pulse"
-                      style={{ backgroundColor: currentMedia?.type === 'video' ? '#8a2be2' : '#ff00de' }}
+                      style={{
+                        backgroundColor:
+                          currentMedia?.type === "video"
+                            ? "#8a2be2"
+                            : "#ff00de",
+                      }}
                     />
                     <span className="text-xs text-cyber-glow font-mono">
-                      {currentMedia?.type === 'video' ? 'VIDEO.CONTENT' : 'IMAGE.CONTENT'}
+                      {currentMedia?.type === "video"
+                        ? "VIDEO.CONTENT"
+                        : "IMAGE.CONTENT"}
                     </span>
                   </div>
                   <div className="flex items-center space-x-2">
                     <div className="w-2 h-2 bg-neon-green rounded-full animate-pulse" />
-                    <span className="text-xs text-cyber-glow font-mono">COMMUNITY_UPLOAD</span>
+                    <span className="text-xs text-cyber-glow font-mono">
+                      COMMUNITY_UPLOAD
+                    </span>
                   </div>
                 </div>
                 <div className="text-xs text-muted-foreground font-mono">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -409,8 +409,14 @@ export default function Index() {
               {/* Fan Image 1 */}
               <motion.div
                 whileHover={{ scale: 1.02, y: -5 }}
-                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group"
+                className="fan-item cyber-border bg-cyber-deep/30 p-4 rounded-lg hover-glow backdrop-blur-sm group cursor-pointer"
                 style={{ borderColor: "#ff00de" }}
+                onClick={() => openLightbox(
+                  "https://cdn.builder.io/api/v1/image/assets%2F0633d7dd76bc46b5ae429b203d2a5219%2F5d25bf673e48461eaef1a2efe579780d?format=webp&width=800",
+                  "CYBERPUNK.PORTRAIT",
+                  "Digital fan art creation",
+                  "image"
+                )}
               >
                 <div className="relative overflow-hidden rounded-lg mb-4">
                   <img
@@ -420,6 +426,11 @@ export default function Index() {
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-neon-pink/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                   <div className="absolute top-2 right-2 w-3 h-3 bg-neon-pink rounded-full animate-glow-pulse" />
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <div className="w-12 h-12 rounded-full bg-cyber-dark/90 border-2 border-neon-pink flex items-center justify-center backdrop-blur-sm animate-glow-pulse">
+                      <span className="text-neon-pink text-lg font-mono">👁</span>
+                    </div>
+                  </div>
                 </div>
                 <div className="space-y-2">
                   <h3 className="text-lg font-bold text-neon-pink font-mono">CYBERPUNK.PORTRAIT</h3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "fusion-starter",
-      "hasInstallScript": true,
       "dependencies": {
         "dotenv": "^17.2.0",
         "express": "^4.18.2",


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements a fan creations section with lightbox functionality to display community-generated content. Users requested the ability to view fan art and videos in a popup lightbox similar to gallery websites, with proper image/video sizing and removal of duplicate close buttons.

## Code changes

- **Added fan creations section** with grid layout displaying community art and videos
- **Implemented lightbox modal** using Dialog component for full-screen media viewing
- **Added media viewer functionality** supporting both images and videos with proper scaling
- **Fixed lightbox styling** to fit media perfectly within viewport bounds and removed duplicate close buttons
- **Updated mock data** in Spotify playlist with real track information
- **Simplified toast theming** by removing theme dependency and setting to dark mode
- **Added lightbox state management** for opening/closing media with proper metadata display
- **Enhanced UI with cyberpunk styling** including neon borders, animations, and hover effects

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0aaf015ebbab475593d922c07022b893/vibe-sanctuary)

👀 [Preview Link](https://0aaf015ebbab475593d922c07022b893-vibe-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0aaf015ebbab475593d922c07022b893</projectId>-->
<!--<branchName>vibe-sanctuary</branchName>-->